### PR TITLE
enforced TLS version 1.2, node-node encryption and encryption at rest…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### **Added**
 
+- enforced TLS version 1.2, node-node encryption and encryption at rest on OS module
+ 
 ### **Changed**
 
 ### **Removed**

--- a/modules/storage/opensearch/stack.py
+++ b/modules/storage/opensearch/stack.py
@@ -115,6 +115,9 @@ class OpenSearchStack(Stack):  # type: ignore
             access_policies=[iam.PolicyStatement.from_json(os_access_policy)],
             domain_name=dep_mod,
             enforce_https=True,
+            node_to_node_encryption=True,
+            encryption_at_rest=opensearch.EncryptionAtRestOptions(enabled=True),
+            tls_security_policy=opensearch.TLSSecurityPolicy.TLS_1_2,
         )
 
         url = f"https://{os_domain.domain_endpoint}/_dashboards/"


### PR DESCRIPTION
*Issue #, if available:*
Fixes #22 

*Description of changes:*
enforced TLS version 1.2, node-node encryption and encryption at rest on OS module

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
