### PR TITLE
updating Pillow lib in emr-serverless requirments for mwaa data file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - replaced exporting metadata with seedfarmer command
 - storage/buckets - added `usedforsecurity=False` to the sha1 creation of bucket names
 - applying changes based off security scans and code standards recommendations
+- `data/mwaa/requirements/requirements-emr-serverless.txt` updated `Pillow~=9.2.0` as per bot
 
 ### **Removed**
 

--- a/data/mwaa/requirements/requirements-emr-serverless.txt
+++ b/data/mwaa/requirements/requirements-emr-serverless.txt
@@ -1,4 +1,4 @@
-Pillow~=9.0.1
+Pillow~=9.2.0
 boto3~=1.23.9
 awscli~=1.24.9
 airflow-kubernetes-job-operator~=2.0.4


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The file `data/mwaa/requirements/requirements-emr-serverless.txt` was updated with Pillow~=9.2.0 as per dependabot request

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
