### PR TITLE
updated reqs.txt for emr-serverless module to support mwaa 2.6.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - storage/buckets - added `usedforsecurity=False` to the sha1 creation of bucket names
 - applying changes based off security scans and code standards recommendations
 - `data/mwaa/requirements/requirements-emr-serverless.txt` updated `Pillow~=9.3.0` as per bot
+- changed the `data/mwaa/requirements/requirements-emr-serverless.txt` to support Amazon MWAA 2.6.3 version
 
 ### **Removed**
 

--- a/data/mwaa/requirements/requirements-emr-serverless.txt
+++ b/data/mwaa/requirements/requirements-emr-serverless.txt
@@ -1,9 +1,3 @@
 Pillow~=9.3.0
-boto3~=1.23.9
-awscli~=1.24.9
-airflow-kubernetes-job-operator~=2.0.4
-apache-airflow-providers-cncf-kubernetes~=2.1.0
-boto3-stubs[essential]~=1.21.37
-mypy-boto3-batch~=1.22.8
-sagemaker==2.100.0
+sagemaker==2.180.0
 emr_serverless @ https://github.com/aws-samples/emr-serverless-samples/releases/download/v1.0.1/mwaa_plugin.zip


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
updated reqs.txt for emr-serverless module to support mwaa 2.6.3

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
