### PR TITLE
forcing app to stop in emr-s prior to deletion

### DIFF
--- a/modules/compute/emr-serverless/deployspec.yaml
+++ b/modules/compute/emr-serverless/deployspec.yaml
@@ -19,5 +19,7 @@ destroy:
       - pip install -r requirements.txt
     build:
       commands:
+      - export EMR_APP_ID=$(echo $SEEDFARMER_MODULE_METADATA | jq -r '."EmrApplicationId"') || true
+      - aws emr-serverless stop-application --application-id $EMR_APP_ID || true
       - cdk destroy --force --app "python app.py"
 

--- a/modules/compute/emr-serverless/modulestack.yaml
+++ b/modules/compute/emr-serverless/modulestack.yaml
@@ -23,6 +23,11 @@ Resources:
             Effect: Allow
             Resource:
               - !Sub "arn:aws:iam::${AWS::AccountId}:role/aws-service-role/*.amazonaws.com/*"
+          - Action:
+              - "emr-serverless:StopApplication"
+            Effect: Allow
+            Resource:
+              - !Sub "arn:aws:emr-serverless:${AWS::Region}:${AWS::AccountId}:/applications/*"
           # Wildcard use on the specfic resources created by seedfarmer
         Version: 2012-10-17
       PolicyName: "modulespecific-policy"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Trying to destroy an EMR-Serverless that has started applications prevents deletion.  Adding code to stop the started application on this cluster for deletion.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
