### PR TITLE
add logic to validate relative paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - added paginatior for CFN list stacks to scrape the stacks starting with `addf` for registering the apps to appregistry
 - updated `Pillow~=10.0.1` in `mwaa/requirements/requirements*.txt` and in `data/mwaa/requirements/requirements-emr-serverless.txt`
 - reduced the length of s3 bucket name for docker images replication to fix failures caused due to naming length
+- added logic to validate relative paths in `storage/fsx-lustre` module
 
 ### **Removed**
 

--- a/modules/storage/fsx-lustre/app.py
+++ b/modules/storage/fsx-lustre/app.py
@@ -49,6 +49,14 @@ if "SCRATCH" in fs_deployment_type and storage_throughput is not None:
 if "PERSISTENT" in fs_deployment_type and storage_throughput is None:
     raise ValueError(f"The storage throughput must be specified for Lustre fs_deployment_type={fs_deployment_type}")
 
+
+def fix_paths(p: str) -> str:
+    if p:
+        return f"/{p}" if not p.startswith("/") else p
+    else:
+        return p
+
+
 app = App()
 
 stack = FsxFileSystem(
@@ -61,8 +69,8 @@ stack = FsxFileSystem(
     module_name=module_name,
     private_subnet_ids=private_subnet_ids,
     vpc_id=vpc_id,
-    import_path=import_path,
-    export_path=export_path,
+    import_path=fix_paths(import_path),  # type: ignore
+    export_path=fix_paths(export_path),  # type: ignore
     storage_throughput=storage_throughput,  # type: ignore
     env=Environment(account=os.environ["CDK_DEFAULT_ACCOUNT"], region=os.environ["CDK_DEFAULT_REGION"]),
 )

--- a/modules/storage/fsx-lustre/tests/test_app.py
+++ b/modules/storage/fsx-lustre/tests/test_app.py
@@ -19,7 +19,7 @@ def stack_defaults():
     os.environ["SEEDFARMER_PARAMETER_PRIVATE_SUBNET_IDS"] = '["subnet-1234","subnet-5678"]'
     os.environ["SEEDFARMER_PARAMETER_FS_DEPLOYMENT_TYPE"] = "PERSISTENT_1"
     os.environ["SEEDFARMER_PARAMETER_IMPORT_PATH"] = "somepathin/"
-    os.environ["SEEDFARMER_PARAMETER_EXPORT_PATH"] = "somepatout/"
+    os.environ["SEEDFARMER_PARAMETER_EXPORT_PATH"] = "somepathout/"
     os.environ["SEEDFARMER_PARAMETER_DATA_BUCKET_NAME"] = "thbucketname"
     os.environ["SEEDFARMER_PARAMETER_STORAGE_THROUGHPUT"] = "50"
 
@@ -98,3 +98,13 @@ def test_throughput_invalid(stack_defaults):
     os.environ["SEEDFARMER_PARAMETER_STORAGE_THROUGHPUT"] = "text"
     with pytest.raises(Exception):
         import app  # noqa: F811 F401
+
+
+def test_fixpaths(stack_defaults):
+    import app  # noqa: F811 F401
+
+    without_path = app.fix_paths("missingleading/missing")
+    with_path = app.fix_paths("/has/leading/")
+
+    assert without_path == "/missingleading/missing"
+    assert with_path == "/has/leading/"


### PR DESCRIPTION
*Issue #, if available:*
#93 
*Description of changes:*
If a manifest passes in a relative import or export path that is missing a leading `/`, we will add it

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
