### PR TITLE
Add EKS Node Role and upgrade IMDS to vAdd EKS Node Role and upgrade IMDS to v2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - modules/storage/buckets
   - modules/storage/opensearch
 - added ability for artifact buckets to write events to event bridge.
+- added eks node iam role that all eks nodes will assume on start
 
 ### **Changed**
 
@@ -49,6 +50,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - updated `Pillow~=10.0.1` in `mwaa/requirements/requirements*.txt` and in `data/mwaa/requirements/requirements-emr-serverless.txt`
 - reduced the length of s3 bucket name for docker images replication to fix failures caused due to naming length
 - added logic to validate relative paths in `storage/fsx-lustre` module, accept `fsx-version` input parameter
+- added logic to require IMDSv2 in eks nodes
 
 ### **Removed**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## UNRELEASED
 
 ### **Added**
+- added eks node iam role that all eks nodes will assume on start
 
 ### **Changed**
+- added logic to require IMDSv2 in eks nodes
 
 ### **Removed**
 
@@ -37,7 +39,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - modules/storage/buckets
   - modules/storage/opensearch
 - added ability for artifact buckets to write events to event bridge.
-- added eks node iam role that all eks nodes will assume on start
 
 ### **Changed**
 
@@ -50,7 +51,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - updated `Pillow~=10.0.1` in `mwaa/requirements/requirements*.txt` and in `data/mwaa/requirements/requirements-emr-serverless.txt`
 - reduced the length of s3 bucket name for docker images replication to fix failures caused due to naming length
 - added logic to validate relative paths in `storage/fsx-lustre` module, accept `fsx-version` input parameter
-- added logic to require IMDSv2 in eks nodes
 
 ### **Removed**
 

--- a/modules/compute/eks/README.md
+++ b/modules/compute/eks/README.md
@@ -112,7 +112,7 @@ EKS integrates with AWS Identity and Access Management (IAM) to control access t
 - `EksOidcArn`: The EKS Cluster's OIDC Arn
 - `EksClusterOpenIdConnectIssuer`: EKS Cluster's OPEN ID Issuer
 - `CNIMetricsHelperRoleName`: Name of role created for CNIMetricHelper SA
-- `EksClusterMasterRoleArn` - the masterrole used for cluster creation
+- `EksNodeRoleArn` - the role assigned to nodes when nodes are spinning up in node groups.
 
 #### Output Example
 
@@ -124,7 +124,8 @@ EKS integrates with AWS Identity and Access Management (IAM) to control access t
   "EksOidcArn": "arn:aws:iam::XXXXXXXX:oidc-provider/oidc.eks.us-west-2.amazonaws.com/id/XXXXXXXX",
   "EksClusterOpenIdConnectIssuer": "oidc.eks.us-west-2.amazonaws.com/id/098FBE7B04A9C399E4A3534FF1C288C6",
   "CNIMetricsHelperRoleName": "idf-dataservice-core-eks-CNIMetricsHelperRole",
-  "EksClusterMasterRoleArn" : "arn:aws:iam::XXXXXXXX:role/idf-local-core-eks-us-east-1-masterrole"
+  "EksClusterMasterRoleArn" : "arn:aws:iam::XXXXXXXX:role/idf-local-core-eks-us-east-1-masterrole",
+  "EksNodeRoleArn": "arn:aws:iam::XXXXXXXX:role/idf-local-core-eks-us-east-1-noderole"
 }
 
 ```

--- a/modules/compute/eks/README.md
+++ b/modules/compute/eks/README.md
@@ -112,6 +112,7 @@ EKS integrates with AWS Identity and Access Management (IAM) to control access t
 - `EksOidcArn`: The EKS Cluster's OIDC Arn
 - `EksClusterOpenIdConnectIssuer`: EKS Cluster's OPEN ID Issuer
 - `CNIMetricsHelperRoleName`: Name of role created for CNIMetricHelper SA
+- `EksClusterMasterRoleArn` - the masterrole used for cluster creation
 - `EksNodeRoleArn` - the role assigned to nodes when nodes are spinning up in node groups.
 
 #### Output Example

--- a/modules/compute/eks/app.py
+++ b/modules/compute/eks/app.py
@@ -91,6 +91,7 @@ CfnOutput(
             "CNIMetricsHelperRoleName": stack.cni_metrics_role_name,
             # Cluster Master role created as a part of this stack gets added to RBAC system:masters group
             "EksClusterMasterRoleArn": stack.eks_cluster_masterrole.role_arn,
+            "EksNodeRoleArn": stack.node_role.role_arn,
         }
     ),
 )

--- a/modules/compute/eks/stack.py
+++ b/modules/compute/eks/stack.py
@@ -334,6 +334,23 @@ class Eks(Stack):  # type: ignore
         # This depends both on the service account and the patches to the existing CNI resources having been done first
         vpc_cni_chart.node.add_dependency(sg_pods_service_account)
 
+        # Node role for all nodes
+        self.node_role = iam.Role(
+            self,
+            "NodeRole",
+            role_name=f"{project_name}-{deployment_name}-{module_name}-{self.region}-noderole",
+            assumed_by=iam.ServicePrincipal("ec2.amazonaws.com"),
+            description="Role for EKS nodes",
+        )
+        self.node_role.add_managed_policy(
+            iam.ManagedPolicy.from_aws_managed_policy_name("AmazonSSMManagedInstanceCore")
+        )
+        self.node_role.add_managed_policy(
+            iam.ManagedPolicy.from_aws_managed_policy_name("AmazonEC2ContainerRegistryReadOnly")
+        )
+        self.node_role.add_managed_policy(iam.ManagedPolicy.from_aws_managed_policy_name("AmazonEKS_CNI_Policy"))
+        self.node_role.add_managed_policy(iam.ManagedPolicy.from_aws_managed_policy_name("AmazonEKSWorkerNodePolicy"))
+
         # Add Managed Node Group(s)
         if eks_compute_config.get("eks_nodegroup_config"):
             # Spot InstanceType
@@ -359,6 +376,9 @@ class Eks(Stack):  # type: ignore
                                 ),
                             )
                         ],
+                        metadata_options=ec2.CfnLaunchTemplate.MetadataOptionsProperty(
+                            http_tokens="required", http_put_response_hop_limit=2
+                        ),
                     ),
                 )
 
@@ -374,6 +394,7 @@ class Eks(Stack):  # type: ignore
                     labels=ng.get("eks_node_labels") if ng.get("eks_node_labels") else None,
                     release_version=get_ami_version(str(eks_version)),
                     subnets=ec2.SubnetSelection(subnets=self.dataplane_subnets),
+                    node_role=self.node_role,
                 )
 
                 nodegroup.role.add_managed_policy(
@@ -1525,7 +1546,6 @@ class Eks(Stack):  # type: ignore
             )
 
             if eks_addons_config.get("deploy_calico"):
-
                 with open(os.path.join(project_dir, "network-policies/default-allow-kyverno.json"), "r") as f:
                     default_allow_kyverno_policy_file = f.read()
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- DCV module requires to use IMDS service to determine whether it is a EC2 instance. It is recommended to use IMDSv2 for all ec2 instances. This CR makes IMDSv2 required in all nodes launched by eks.
- Use a designated role for all the nodes. Without this PR, all the nodes created by eks will have a randomly generated role. This CRs makes all the nodes to share the same Role. When we launch the DCV, we will add the permission to access DCV licenses in s3. The permission to access licenses will be added to this role.

- Also validated and fix formatting. Adding required output to README.md and CHANGELOG.md

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
