### PR TITLE
chore: Add integration tests for network basic-cdk module

### DIFF
--- a/modules/network/basic-cdk/integ/integ_network.py
+++ b/modules/network/basic-cdk/integ/integ_network.py
@@ -1,6 +1,5 @@
 import datetime
 import sys
-import uuid
 
 import aws_cdk as cdk
 import aws_cdk.cloud_assembly_schema as cas
@@ -19,7 +18,7 @@ integration.IntegTest(
     test_cases=[
         stack.NetworkingStack(
             app,
-            f"network-public-{str(uuid.uuid4())[:8]}",
+            "network-public",
             project_name="integ",
             deployment_name="testing",
             module_name="basic-cdk",
@@ -30,7 +29,7 @@ integration.IntegTest(
         ),
         stack.NetworkingStack(
             app,
-            f"network-private-{str(uuid.uuid4())[:8]}",
+            "network-private",
             project_name="integ",
             deployment_name="testing",
             module_name="basic-cdk",

--- a/modules/network/basic-cdk/integ/integ_network.py
+++ b/modules/network/basic-cdk/integ/integ_network.py
@@ -14,7 +14,7 @@ timestamp = datetime.datetime.now()
 
 integration.IntegTest(
     app,
-    "Integration Tests Buckets Module",
+    "Integration Tests Basic Module",
     test_cases=[
         stack.NetworkingStack(
             app,

--- a/modules/network/basic-cdk/integ/integ_network.py
+++ b/modules/network/basic-cdk/integ/integ_network.py
@@ -1,5 +1,6 @@
 import datetime
 import sys
+import uuid
 
 import aws_cdk as cdk
 import aws_cdk.cloud_assembly_schema as cas
@@ -18,7 +19,7 @@ integration.IntegTest(
     test_cases=[
         stack.NetworkingStack(
             app,
-            "network-public",
+            f"network-public-{str(uuid.uuid4())[:8]}",
             project_name="integ",
             deployment_name="testing",
             module_name="basic-cdk",
@@ -29,7 +30,7 @@ integration.IntegTest(
         ),
         stack.NetworkingStack(
             app,
-            "network-private",
+            f"network-private-{str(uuid.uuid4())[:8]}",
             project_name="integ",
             deployment_name="testing",
             module_name="basic-cdk",

--- a/modules/network/basic-cdk/integ/integ_network.py
+++ b/modules/network/basic-cdk/integ/integ_network.py
@@ -1,0 +1,45 @@
+import datetime
+import sys
+
+import aws_cdk as cdk
+import aws_cdk.cloud_assembly_schema as cas
+import aws_cdk.integ_tests_alpha as integration
+
+sys.path.append("../")
+
+import stack  # noqa: E402
+
+app = cdk.App()
+timestamp = datetime.datetime.now()
+
+integration.IntegTest(
+    app,
+    "Integration Tests Buckets Module",
+    test_cases=[
+        stack.NetworkingStack(
+            app,
+            "network-public",
+            project_name="integ",
+            deployment_name="testing",
+            module_name="basic-cdk",
+            internet_accessible=True,
+            stack_description=f"Integration Test: {timestamp.month}-{timestamp.day} {timestamp.hour}:{timestamp.minute}",
+        ),
+        stack.NetworkingStack(
+            app,
+            "network-private",
+            project_name="integ",
+            deployment_name="testing",
+            module_name="basic-cdk",
+            internet_accessible=False,
+            stack_description=f"Integration Test: {timestamp.month}-{timestamp.day} {timestamp.hour}:{timestamp.minute}",
+        )
+    ],
+    diff_assets=True,
+    stack_update_workflow=True,
+    cdk_command_options=cas.CdkCommands(
+        deploy=cas.DeployCommand(args=cas.DeployOptions(require_approval=cas.RequireApproval.NEVER, json=True)),
+        destroy=cas.DestroyCommand(args=cas.DestroyOptions(force=True)),
+    ),
+)
+app.synth()

--- a/modules/network/basic-cdk/integ/integ_network.py
+++ b/modules/network/basic-cdk/integ/integ_network.py
@@ -23,7 +23,9 @@ integration.IntegTest(
             deployment_name="testing",
             module_name="basic-cdk",
             internet_accessible=True,
-            stack_description=f"Integration Test: {timestamp.month}-{timestamp.day} {timestamp.hour}:{timestamp.minute}",
+            stack_description=f"""
+            Integration Test: {timestamp.month}-{timestamp.day} {timestamp.hour}:{timestamp.minute}
+            """,
         ),
         stack.NetworkingStack(
             app,
@@ -32,8 +34,10 @@ integration.IntegTest(
             deployment_name="testing",
             module_name="basic-cdk",
             internet_accessible=False,
-            stack_description=f"Integration Test: {timestamp.month}-{timestamp.day} {timestamp.hour}:{timestamp.minute}",
-        )
+            stack_description=f"""
+            Integration Test: {timestamp.month}-{timestamp.day} {timestamp.hour}:{timestamp.minute}
+            """,
+        ),
     ],
     diff_assets=True,
     stack_update_workflow=True,

--- a/modules/network/basic-cdk/requirements.txt
+++ b/modules/network/basic-cdk/requirements.txt
@@ -18,6 +18,7 @@ aws-cdk-lib==2.82.0
     # via
     #   -r requirements.in
     #   cdk-nag
+aws_cdk.integ-tests-alpha==2.82.0a0
 cattrs==22.2.0
     # via jsii
 cdk-nag==2.12.29

--- a/modules/network/basic-cdk/setup.cfg
+++ b/modules/network/basic-cdk/setup.cfg
@@ -24,5 +24,5 @@ strict = True
 ignore_missing_imports = True
 allow_untyped_decorators = True
 exclude =
-  codeseeder.out/|example/|tests/
+  codeseeder.out/|example/|tests/|integ/
 warn_unused_ignores = False


### PR DESCRIPTION
### Description
Adding integration tests for idf module `network/basic-cdk`
- Test Cases
  - _Network Accessible_
  - _Network Not Accessible_

### Testing 
Run locally successfully
```shell
Running in parallel across regions: us-east-1, us-east-2, us-west-2
Running test /Users/hansonlu/work/awslabs/code/idf-modules/modules/network/basic-cdk/integ/integ_network.py in us-east-1
  SUCCESS    integ/integ_network-Integration Tests Buckets Module/DefaultTest 771.749s
       NO ASSERTIONS

Test Results:

Tests:    1 passed, 1 total
```

Run again in workflow below

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
