### PR TITLE
[Feature Improvement] Replication Module Improvements (Rate Limits & Race Conditions)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### **Added**
 
 - added Opensearch serverless module
+- updated replication module to only pull when an image hasn't been replicated already
 
 ### **Changed**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### **Added**
 
 - added Opensearch serverless module
-- updated replication module to only pull when an image hasn't been replicated already
+- updated replication module to avoid docker pull rate limits and resource creation race conditions
 
 ### **Changed**
 

--- a/modules/replication/dockerimage-replication/deployspec.yaml
+++ b/modules/replication/dockerimage-replication/deployspec.yaml
@@ -14,8 +14,10 @@ deploy:
           if ! aws s3api head-bucket --bucket "${S3_BUCKET_NAME}"; then
             if [ ${AWS_DEFAULT_REGION} == "us-east-1" ]; then
               aws s3api create-bucket --bucket "${S3_BUCKET_NAME}" --region "${AWS_DEFAULT_REGION}"
+              sleep 15
             else
               aws s3api create-bucket --bucket "${S3_BUCKET_NAME}" --region "${AWS_DEFAULT_REGION}" --create-bucket-configuration LocationConstraint=${AWS_DEFAULT_REGION}
+              sleep 15
             fi
           fi
         - python3 get-list-of-eks-images.py --eks-version ${SEEDFARMER_PARAMETER_EKS_VERSION} --versions-directory data/eks_dockerimage-replication/versions --update-helm-repos --registry-prefix "${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/${AWS_CODESEEDER_NAME}-"

--- a/modules/replication/dockerimage-replication/deployspec.yaml
+++ b/modules/replication/dockerimage-replication/deployspec.yaml
@@ -13,12 +13,11 @@ deploy:
         - |
           if ! aws s3api head-bucket --bucket "${S3_BUCKET_NAME}"; then
             if [ ${AWS_DEFAULT_REGION} == "us-east-1" ]; then
-              aws s3api create-bucket --bucket "${S3_BUCKET_NAME}" --region "${AWS_DEFAULT_REGION}"
-              sleep 15
+              aws s3api create-bucket --bucket "${S3_BUCKET_NAME}" --region "${AWS_DEFAULT_REGION}" 
             else
               aws s3api create-bucket --bucket "${S3_BUCKET_NAME}" --region "${AWS_DEFAULT_REGION}" --create-bucket-configuration LocationConstraint=${AWS_DEFAULT_REGION}
-              sleep 15
             fi
+            sleep 15
           fi
         - python3 get-list-of-eks-images.py --eks-version ${SEEDFARMER_PARAMETER_EKS_VERSION} --versions-directory data/eks_dockerimage-replication/versions --update-helm-repos --registry-prefix "${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_DEFAULT_REGION}.amazonaws.com/${AWS_CODESEEDER_NAME}-"
         - chmod +x replication.sh

--- a/modules/replication/dockerimage-replication/replication.sh
+++ b/modules/replication/dockerimage-replication/replication.sh
@@ -26,7 +26,8 @@ create() {
     docker pull $image
     # Setting connection with AWS ECR
     DESCRIBE_REPO=$(aws ecr describe-repositories --repository-names $TARGET_REPOSITORY_NAME )
-    if [ $DESCRIBE_REPO -ne 0 ]; then
+    DESCRIBE_REPO_STATUS=$?
+    if [ $DESCRIBE_REPO_STATUS -ne 0 ]; then
         echo "$TARGET_REPOSITORY_NAME not found in ECR. Creating..."
         aws ecr create-repository --repository-name $TARGET_REPOSITORY_NAME --image-scanning-configuration scanOnPush=true
         sleep 10

--- a/modules/replication/dockerimage-replication/replication.sh
+++ b/modules/replication/dockerimage-replication/replication.sh
@@ -18,7 +18,7 @@ create() {
     TARGET_REPOSITORY_NAME=${AWS_CODESEEDER_NAME}-${image_name}
     IMAGE_META="$( aws ecr batch-get-image --repository-name=$TARGET_REPOSITORY_NAME --image-ids=imageTag=$image_tag --query 'images[].imageId.imageTag' --output text )" || true
     if [[ $IMAGE_META == $image_tag ]]; then
-    echo "$IMAGE_META found in $TARGET_REPOSITORY_NAME skipping build"
+    echo "$IMAGE_META found in $TARGET_REPOSITORY_NAME skipping replication"
     else
     echo "$TARGET_REPOSITORY_NAME:$image_tag not found, fetching"
     echo Pulling $image

--- a/modules/replication/dockerimage-replication/replication.sh
+++ b/modules/replication/dockerimage-replication/replication.sh
@@ -14,17 +14,17 @@ create() {
         IMAGE_ACCOUNT_ID=$(echo $image_name | awk -F '/' '{print $1}' | awk -F '.' '{print $1}')
         aws ecr get-login-password --region $AWS_DEFAULT_REGION | docker login --username AWS --password-stdin $IMAGE_ACCOUNT_ID.dkr.ecr.$AWS_DEFAULT_REGION.amazonaws.com
     fi
-    echo Pulling the $image
 
     TARGET_REPOSITORY_NAME=${AWS_CODESEEDER_NAME}-${image_name}
     IMAGE_META="$( aws ecr batch-get-image --repository-name=$TARGET_REPOSITORY_NAME --image-ids=imageTag=$image_tag --query 'images[].imageId.imageTag' --output text )" || true
     if [[ $IMAGE_META == $image_tag ]]; then
-    echo "$IMAGE_META found skipping build"
+    echo "$IMAGE_META found in $TARGET_REPOSITORY_NAME skipping build"
     else
     echo "$TARGET_REPOSITORY_NAME:$image_tag not found, fetching"
+    echo Pulling $image
     docker pull $image
     # Setting connection with AWS ECR
-    aws ecr describe-repositories --repository-names $TARGET_REPOSITORY_NAME || aws ecr create-repository --repository-name $TARGET_REPOSITORY_NAME --image-scanning-configuration scanOnPush=true
+    aws ecr describe-repositories --repository-names $TARGET_REPOSITORY_NAME || $(aws ecr create-repository --repository-name $TARGET_REPOSITORY_NAME --image-scanning-configuration scanOnPush=true && sleep 10)
     aws ecr get-login-password --region $AWS_DEFAULT_REGION | docker login --username AWS --password-stdin $AWS_ACCOUNT_ID.dkr.ecr.$AWS_DEFAULT_REGION.amazonaws.com
     # Tagging and pushing Docker images according to https://docs.aws.amazon.com/AmazonECR/latest/userguide/docker-pull-ecr-image.html
     docker tag $image $AWS_ACCOUNT_ID.dkr.ecr.$AWS_DEFAULT_REGION.amazonaws.com/$TARGET_REPOSITORY_NAME:${image_tag}

--- a/modules/replication/dockerimage-replication/replication.sh
+++ b/modules/replication/dockerimage-replication/replication.sh
@@ -36,7 +36,8 @@ create() {
 }
 
 destroy() {
-    echo "Sorry... not working"
+    echo "WARNING: The destroy workflow removes the ECR repositories which we were created during replication"
+    python delete-repos.py
 }
 
 $1

--- a/modules/replication/dockerimage-replication/replication.sh
+++ b/modules/replication/dockerimage-replication/replication.sh
@@ -26,7 +26,7 @@ create() {
     docker pull $image
     # Setting connection with AWS ECR
     DESCRIBE_REPO=$(aws ecr describe-repositories --repository-names $TARGET_REPOSITORY_NAME )
-    if [ $check_caller_id_status -ne 0 ]; then
+    if [ $DESCRIBE_REPO -ne 0 ]; then
         echo "$TARGET_REPOSITORY_NAME not found in ECR. Creating..."
         aws ecr create-repository --repository-name $TARGET_REPOSITORY_NAME --image-scanning-configuration scanOnPush=true
         sleep 10

--- a/modules/replication/dockerimage-replication/replication.sh
+++ b/modules/replication/dockerimage-replication/replication.sh
@@ -24,7 +24,8 @@ create() {
     echo Pulling $image
     docker pull $image
     # Setting connection with AWS ECR
-    aws ecr describe-repositories --repository-names $TARGET_REPOSITORY_NAME || $(aws ecr create-repository --repository-name $TARGET_REPOSITORY_NAME --image-scanning-configuration scanOnPush=true && sleep 10)
+    aws ecr describe-repositories --repository-names $TARGET_REPOSITORY_NAME || aws ecr create-repository --repository-name $TARGET_REPOSITORY_NAME --image-scanning-configuration scanOnPush=true
+    sleep 10
     aws ecr get-login-password --region $AWS_DEFAULT_REGION | docker login --username AWS --password-stdin $AWS_ACCOUNT_ID.dkr.ecr.$AWS_DEFAULT_REGION.amazonaws.com
     # Tagging and pushing Docker images according to https://docs.aws.amazon.com/AmazonECR/latest/userguide/docker-pull-ecr-image.html
     docker tag $image $AWS_ACCOUNT_ID.dkr.ecr.$AWS_DEFAULT_REGION.amazonaws.com/$TARGET_REPOSITORY_NAME:${image_tag}

--- a/modules/replication/dockerimage-replication/replication.sh
+++ b/modules/replication/dockerimage-replication/replication.sh
@@ -26,7 +26,7 @@ create() {
     docker pull $image
     # Setting connection with AWS ECR
     DESCRIBE_REPO=$(aws ecr describe-repositories --repository-names $TARGET_REPOSITORY_NAME || echo "REPOSITORY_MISSING" )
-    if [[ $DESCRIBE_REPO_STATUS == "REPOSITORY_MISSING" ]]; then
+    if [[ $DESCRIBE_REPO == "REPOSITORY_MISSING" ]]; then
         echo "$TARGET_REPOSITORY_NAME not found in ECR. Creating..."
         aws ecr create-repository --repository-name $TARGET_REPOSITORY_NAME --image-scanning-configuration scanOnPush=true
         sleep 10

--- a/modules/replication/dockerimage-replication/replication.sh
+++ b/modules/replication/dockerimage-replication/replication.sh
@@ -1,7 +1,6 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
-
-#!/bin/bash 
+#!/bin/bash
 
 set -euo pipefail
 set +x
@@ -16,21 +15,28 @@ create() {
         aws ecr get-login-password --region $AWS_DEFAULT_REGION | docker login --username AWS --password-stdin $IMAGE_ACCOUNT_ID.dkr.ecr.$AWS_DEFAULT_REGION.amazonaws.com
     fi
     echo Pulling the $image
+
+    TARGET_REPOSITORY_NAME=${AWS_CODESEEDER_NAME}-${image_name}
+    IMAGE_META="$( aws ecr batch-get-image --repository-name=$TARGET_REPOSITORY_NAME --image-ids=imageTag=$image_tag --query 'images[].imageId.imageTag' --output text )" || true
+    if [[ $IMAGE_META == $image_tag ]]; then
+    echo "$IMAGE_META found skipping build"
+    else
+    echo "$TARGET_REPOSITORY_NAME:$image_tag not found, fetching"
     docker pull $image
     # Setting connection with AWS ECR
-    aws ecr describe-repositories --repository-names ${AWS_CODESEEDER_NAME}-${image_name} || aws ecr create-repository --repository-name ${AWS_CODESEEDER_NAME}-${image_name} --image-scanning-configuration scanOnPush=true
+    aws ecr describe-repositories --repository-names $TARGET_REPOSITORY_NAME || aws ecr create-repository --repository-name $TARGET_REPOSITORY_NAME --image-scanning-configuration scanOnPush=true
     aws ecr get-login-password --region $AWS_DEFAULT_REGION | docker login --username AWS --password-stdin $AWS_ACCOUNT_ID.dkr.ecr.$AWS_DEFAULT_REGION.amazonaws.com
     # Tagging and pushing Docker images according to https://docs.aws.amazon.com/AmazonECR/latest/userguide/docker-pull-ecr-image.html
-    docker tag $image $AWS_ACCOUNT_ID.dkr.ecr.$AWS_DEFAULT_REGION.amazonaws.com/${AWS_CODESEEDER_NAME}-${image_name}:${image_tag}
-    docker push $AWS_ACCOUNT_ID.dkr.ecr.$AWS_DEFAULT_REGION.amazonaws.com/${AWS_CODESEEDER_NAME}-${image_name}:${image_tag}
+    docker tag $image $AWS_ACCOUNT_ID.dkr.ecr.$AWS_DEFAULT_REGION.amazonaws.com/$TARGET_REPOSITORY_NAME:${image_tag}
+    docker push $AWS_ACCOUNT_ID.dkr.ecr.$AWS_DEFAULT_REGION.amazonaws.com/$TARGET_REPOSITORY_NAME:${image_tag}
     # Deleting so it wouldn't cause issues with codebuild storage space for huge images
     docker rmi $image
+    fi
     done < images.txt
 }
 
 destroy() {
-    echo "WARNING: The destroy workflow removes the ECR repositories which we were created during replication"
-    python delete-repos.py
+    echo "Sorry... not working"
 }
 
 $1

--- a/modules/replication/dockerimage-replication/replication.sh
+++ b/modules/replication/dockerimage-replication/replication.sh
@@ -25,8 +25,14 @@ create() {
     echo Pulling $image
     docker pull $image
     # Setting connection with AWS ECR
-    aws ecr describe-repositories --repository-names $TARGET_REPOSITORY_NAME || aws ecr create-repository --repository-name $TARGET_REPOSITORY_NAME --image-scanning-configuration scanOnPush=true
-    sleep 10
+    DESCRIBE_REPO=$(aws ecr describe-repositories --repository-names $TARGET_REPOSITORY_NAME )
+    if [ $check_caller_id_status -ne 0 ]; then
+        echo "$TARGET_REPOSITORY_NAME not found in ECR. Creating..."
+        aws ecr create-repository --repository-name $TARGET_REPOSITORY_NAME --image-scanning-configuration scanOnPush=true
+        sleep 10
+    else
+        echo "$TARGET_REPOSITORY_NAME found in ECR"
+    fi
     aws ecr get-login-password --region $AWS_DEFAULT_REGION | docker login --username AWS --password-stdin $AWS_ACCOUNT_ID.dkr.ecr.$AWS_DEFAULT_REGION.amazonaws.com
     # Tagging and pushing Docker images according to https://docs.aws.amazon.com/AmazonECR/latest/userguide/docker-pull-ecr-image.html
     docker tag $image $TARGET_ECR_TAG

--- a/modules/replication/dockerimage-replication/replication.sh
+++ b/modules/replication/dockerimage-replication/replication.sh
@@ -25,9 +25,8 @@ create() {
     echo Pulling $image
     docker pull $image
     # Setting connection with AWS ECR
-    DESCRIBE_REPO=$(aws ecr describe-repositories --repository-names $TARGET_REPOSITORY_NAME )
-    DESCRIBE_REPO_STATUS=$?
-    if [ $DESCRIBE_REPO_STATUS -ne 0 ]; then
+    DESCRIBE_REPO=$(aws ecr describe-repositories --repository-names $TARGET_REPOSITORY_NAME || echo "REPOSITORY_MISSING" )
+    if [[ $DESCRIBE_REPO_STATUS == "REPOSITORY_MISSING" ]]; then
         echo "$TARGET_REPOSITORY_NAME not found in ECR. Creating..."
         aws ecr create-repository --repository-name $TARGET_REPOSITORY_NAME --image-scanning-configuration scanOnPush=true
         sleep 10


### PR DESCRIPTION
*Issue #, if available:*
The current replication module doesn't take into account if a repository already exists and always just invokes docker pull. This causes the module to get to a stuck state when hitting the docker API rate limits. 

Additionally, in some of the scripts we invoke create APIs for ECR or S3 and then immediately try to access those resources resulting in a "resource does not exist" exception. Adding sleep time after create API calls to allow resource creation time.

*Description of changes:*

Adding a lookup to see if the image has already been replicated to ECR. If yes, it skips replication.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
