### PR TITLE
fix: Add missing nag suppression for RDS module

### DIFF
--- a/modules/database/rds/stack.py
+++ b/modules/database/rds/stack.py
@@ -139,4 +139,12 @@ class RDSDatabaseStack(cdk.Stack):
                     reason="Retention policy was explicitely set to DESTROY",
                 ),
             )
+        if credential_rotation_days == 0:
+            nag_supressions.append(
+                cdk_nag.NagPackSuppression(
+                    id="AwsSolutions-SMG4",
+                    reason="Rotation was not enabled",
+                ),
+            )
+
         cdk_nag.NagSuppressions.add_stack_suppressions(self, suppressions=nag_supressions)


### PR DESCRIPTION
RDS module was failing to deploy when credential rotation was turned off.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
