### PR TITLE
removing shutil support for creating zip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### **Added**
 
 ### **Changed**
+- in `mwaa` module, moving creation of plugins.zip to the deployspec since shutil errors out in python 3.11.6
 
 ### **Removed**
 

--- a/modules/orchestration/mwaa/app.py
+++ b/modules/orchestration/mwaa/app.py
@@ -3,7 +3,6 @@
 
 import json
 import os
-import shutil
 
 import aws_cdk
 from aws_cdk import App, CfnOutput
@@ -54,9 +53,6 @@ def generate_description() -> str:
 
 
 app = App()
-
-# zip plugin
-shutil.make_archive("plugins/plugins", "zip", "plugins/")
 
 optional_args = {}
 if dag_bucket_name:

--- a/modules/orchestration/mwaa/deployspec.yaml
+++ b/modules/orchestration/mwaa/deployspec.yaml
@@ -22,6 +22,8 @@ deploy:
         fi
       - export UNIQUE_REQUIREMENTS_FILE="${REQUIREMENTS_FILE}-$(date +%s)"
       - echo "Moving ${REQUIREMENTS_FILE} to ${UNIQUE_REQUIREMENTS_FILE}"
+      - echo "Creating Plugins Zip"
+      - zip plugins/plugins.zip plugins/** -r
       - mv ${REQUIREMENTS_FILE} ${UNIQUE_REQUIREMENTS_FILE}
       - cdk deploy --require-approval never --progress events --app "python app.py" --outputs-file ./cdk-exports.json
       # Export metadata

--- a/modules/orchestration/mwaa/stack.py
+++ b/modules/orchestration/mwaa/stack.py
@@ -40,7 +40,6 @@ class MWAAStack(Stack):  # type: ignore
         stack_description: str,
         **kwargs: Any,
     ) -> None:
-
         # CDK Env Vars
         account: str = aws_cdk.Aws.ACCOUNT_ID
         region: str = aws_cdk.Aws.REGION


### PR DESCRIPTION
*Issue #, if available:*
#124 

*Description of changes:*
Move the creation of the plugins.zip from app.py to deployspec b/c python 3.11.6 has an issue with shutil.  This is now done in deployspec via commandline 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
