### PR TITLE
chore: Update instance type for RDS module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### **Changed**
 
+- update MySQL instance to use T3 instance type
+
 ### **Removed**
 
 =======

--- a/manifests/local/database-modules.yaml
+++ b/manifests/local/database-modules.yaml
@@ -39,7 +39,7 @@ parameters:
   - name: engine-version
     value: 8.0.35
   - name: instance-type
-    value: t2.small
+    value: t3.small
   - name: admin-username
     value: admin
   - name: credential-rotation-days

--- a/modules/database/rds/README.md
+++ b/modules/database/rds/README.md
@@ -64,7 +64,7 @@ parameters:
   - name: engine-version
     value: 8.0.35
   - name: instance-type
-    value: t2.small
+    value: t3.small
   - name: admin-username
     value: admin
   - name: credential-rotation-days

--- a/modules/database/rds/app.py
+++ b/modules/database/rds/app.py
@@ -41,7 +41,7 @@ username: str = _get_env("ADMIN_USERNAME", required=True)  # type: ignore[assign
 database_name: str = _get_env("DATABASE_NAME", required=True)  # type: ignore[assignment]
 
 port: str | None = _get_env("PORT", required=False)
-instance_type: str = _get_env("INSTANCE_TYPE", required=False, default="t2.small")  # type: ignore[assignment]
+instance_type: str = _get_env("INSTANCE_TYPE", required=False, default="t3.small")  # type: ignore[assignment]
 credential_rotation_days: int = int(
     _get_env("CREDENTIAL_ROTATION_DAYS", required=False, default="0"),  # type: ignore[arg-type]
 )

--- a/modules/database/rds/tests/test_stack.py
+++ b/modules/database/rds/tests/test_stack.py
@@ -24,7 +24,7 @@ def stack_defaults() -> None:
 RDS_ENGINE_SETTINGS = {
     "mysql": {
         "engine_version": "8.0.35",
-        "instance_type": "t2.small",
+        "instance_type": "t3.small",
     },
     "postgresql": {
         "engine_version": "14.5",


### PR DESCRIPTION
*Description of changes:*

I'm updating the instance type for the MySQL DB after getting this message from AWS:
> Starting March 11, 2024, Amazon RDS will begin disabling the creation of Amazon RDS for MySQL, MariaDB, and PostgreSQL database instances running on M4, R4, or T2 instance types. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
