### PR TITLE
chore: exporting kubectl handler iam role

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### **Added**
 
 - added KMS/AES encryption and image scan on push to `ecr` module
+- exporting `kubectl lambda iam role arn` for running kubectl calls from the downstream stacks
 
 ### **Changed**
 

--- a/modules/compute/eks/app.py
+++ b/modules/compute/eks/app.py
@@ -94,6 +94,7 @@ CfnOutput(
             "EksClusterOpenIdConnectIssuer": stack.eks_cluster.cluster_open_id_connect_issuer,
             # Cluster Master role created as a part of this stack gets added to RBAC system:masters group
             "EksClusterMasterRoleArn": stack.eks_cluster_masterrole.role_arn,
+            "EksHandlerRoleArn": stack.eks_cluster.kubectl_lambda_role.role_arn,
             "EksNodeRoleArn": stack.node_role.role_arn,
         }
     ),


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
exporting `kubectl handler iam role` for running kubectl calls from the downstream modules

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
