### PR TITLE
chore: set `auto_delete_images` to `True` when removal policy is **DESTROY**

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - fix: `storage/buckets` Correct issues with bucket names above character limit
 - chore: mwaa dags bucket auto delete objects
 - set Pillow version to 10.3.0 as per bot recommendation
+- `storage/ecr` set `auto_delete_images` to `True` when removal policy is **DESTROY**
 
 ### **Removed**
 

--- a/modules/storage/ecr/stack.py
+++ b/modules/storage/ecr/stack.py
@@ -43,6 +43,7 @@ class EcrStack(Stack):
             repository_name=repository_name,
             image_tag_mutability=IMAGE_MUTABILITY[image_tag_mutability],
             removal_policy=RemovalPolicy.DESTROY if removal_policy in ["DESTROY"] else RemovalPolicy.RETAIN,
+            auto_delete_images=True if removal_policy in ["DESTROY"] else False,
             image_scan_on_push=image_scan_on_push,
             encryption=ENCRYPTION[encryption],
             encryption_key=kms.Key.from_key_arn(self, "Key", key_arn=kms_key_arn)


### PR DESCRIPTION
*Issue #, if available:*
- Integration Testing Refactoring 

*Description of changes:*
set `auto_delete_images` to `True` when removal policy is **DESTROY**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
