### PR TITLE
feat: Add generate module metadata action

### DIFF
--- a/.github/workflows/generate-module-metadata.yml
+++ b/.github/workflows/generate-module-metadata.yml
@@ -1,0 +1,36 @@
+name: Generate Module Metadata
+
+on:
+  push:
+    branches: ["release/**"]
+
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version of documentation to generate and release, x.y.z'     
+        required: true
+jobs:
+  build:
+    name: Generate Metadata
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: [3.10]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Set Version ➕
+        run: |
+          if [ -z ${{ github.event.inputs.version }} ]; then echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV; else echo "RELEASE_VERSION=${{ github.event.inputs.version }}" >> $GITHUB_ENV; fi
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Generate Metadata
+        run: |
+          python -m pip install --upgrade pip
+          pip install argparse
+          python scripts/generate-module-metadata.py --v 1.0.0 -n ${{ github.event.repository.name }}

--- a/scripts/generate-module-metadata.py
+++ b/scripts/generate-module-metadata.py
@@ -1,0 +1,46 @@
+import argparse
+import glob
+import os
+from pprint import pprint
+from typing import Dict, List
+
+CWD = os.getcwd()
+
+parser = argparse.ArgumentParser(description='Generate module metadata')
+parser.add_argument('-v','--version', help='Version', required=True)
+parser.add_argument('-n','--repo-name', help='Repo Name', required=True)
+parser.add_argument('--org-name', help='Github Organization Name', default="awslabs", required=False)
+parser.add_argument('-i','--ignore-regex', help='Regex pattern to ignore from collection', required=False)
+
+args = parser.parse_args()
+
+
+def get_all_module_paths(dir: str, level: int) -> List[str]:
+   pattern = dir + level * '/*'
+   return [d[len(CWD):] for d in glob.glob(pattern) if os.path.isdir(d)]
+
+def generate_module_metadata(module_path: str)-> Dict[str, str]:
+    data = {}
+    data["name"] = f"{module_path.split('/')[2]}-{module_path.split('/')[3]}"
+    data["version"] = args.version
+    # Add error handling and case-insensitive filtering
+    data["readme"] = open(f"{CWD}{module_path}/README.md", 'r').read()
+    data["source_url"] = f"https://github.com/{args.org_name}/{args.repo_name}/tree/release/{args.version}{module_path}"
+    data["git_path"] = f"git::https://github.com/{args.org_name}/{args.repo_name}.git/{module_path}/?ref=release/{args.version}"
+    return data
+
+def print_metadata(metadata: Dict[str, str]) -> None:
+    result = {}
+    for k,v in metadata.items():
+        if k is "readme":
+            v = "..."
+        result[k] = v
+    pprint(result)
+
+module_paths = get_all_module_paths(f"{CWD}/modules", 2)
+
+print(f"*** Module Metadata for version {args.version} ***")
+for path in module_paths:
+    metadata = generate_module_metadata(path)
+    # write_metadata_to_s3(bucket, metadata['name'], metadata) # To Implement
+    print_metadata(metadata)


### PR DESCRIPTION
**POC**

### Feature: Add Github Action to collect module metadata and push data to S3

This is just a starting point at the moment.

### When
- Triggered upon a release tag
- For now can be used with workflow dispatch as a test. It is available in my [fork](https://github.com/malachi-constant/idf-modules/actions/workflows/generate-module-metadata.yml)
<img width="1307" alt="Screenshot 2024-06-20 at 3 10 51 PM" src="https://github.com/awslabs/idf-modules/assets/6465221/e643203f-96f0-493b-a89c-7af36f45f80f">

### Example Output
<img width="1261" alt="Screenshot 2024-06-20 at 3 17 03 PM" src="https://github.com/awslabs/idf-modules/assets/6465221/edbab24d-c291-4a3c-893a-eae892776069">


### What Else needs to get done
- Figure out what metadata needs to be present besides `name`, `readme`, `source_url`, `gitpath`, `version`
- Publishing to S3 via the Action.
- Static Site setup using the published metadata as an index.
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
