### PR TITLE
feat: Add generate module metadata action

### DIFF
--- a/.github/workflows/generate-module-metadata.yml
+++ b/.github/workflows/generate-module-metadata.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.10]
+        python-version: ["3.10"]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/generate-module-metadata.yml
+++ b/.github/workflows/generate-module-metadata.yml
@@ -9,6 +9,11 @@ on:
       version:
         description: 'Version of codebase to generate metadata for, x.y.z'     
         required: true
+
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   build:
     name: Generate Metadata
@@ -30,7 +35,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: configure aws credentials
-        uses: aws-actions/configure-aws-credentials@v1.7.0
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: arn:aws:iam::180024969694:role/githubActionsDeployRole
           role-session-name: GitHub_to_AWS_via_FederatedOIDC

--- a/.github/workflows/generate-module-metadata.yml
+++ b/.github/workflows/generate-module-metadata.yml
@@ -43,5 +43,5 @@ jobs:
       - name: Generate Metadata
         run: |
           python -m pip install --upgrade pip
-          pip install argparse
+          pip install argparse, boto3
           python scripts/generate-module-metadata.py -v ${RELEASE_VERSION} -n ${{ github.event.repository.name }} -b ${{ secrets.BUCKET_NAME }}

--- a/.github/workflows/generate-module-metadata.yml
+++ b/.github/workflows/generate-module-metadata.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'Version of documentation to generate and release, x.y.z'     
+        description: 'Version of codebase to generate metadata for, x.y.z'     
         required: true
 jobs:
   build:
@@ -33,4 +33,4 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install argparse
-          python scripts/generate-module-metadata.py --v 1.0.0 -n ${{ github.event.repository.name }}
+          python scripts/generate-module-metadata.py --v ${RELEASE_VERSION} -n ${{ github.event.repository.name }}

--- a/.github/workflows/generate-module-metadata.yml
+++ b/.github/workflows/generate-module-metadata.yml
@@ -29,8 +29,14 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
+      - name: configure aws credentials
+        uses: aws-actions/configure-aws-credentials@v1.7.0
+        with:
+          role-to-assume: ${{ secrets.ROLE_ARN }}
+          role-session-name: GitHub_to_AWS_via_FederatedOIDC
+          aws-region: us-west-2
       - name: Generate Metadata
         run: |
           python -m pip install --upgrade pip
           pip install argparse
-          python scripts/generate-module-metadata.py --v ${RELEASE_VERSION} -n ${{ github.event.repository.name }}
+          python scripts/generate-module-metadata.py -v ${RELEASE_VERSION} -n ${{ github.event.repository.name }} -b ${{ secrets.BUCKET_NAME }}

--- a/.github/workflows/generate-module-metadata.yml
+++ b/.github/workflows/generate-module-metadata.yml
@@ -43,5 +43,5 @@ jobs:
       - name: Generate Metadata
         run: |
           python -m pip install --upgrade pip
-          pip install argparse, boto3
+          pip install argparse boto3
           python scripts/generate-module-metadata.py -v ${RELEASE_VERSION} -n ${{ github.event.repository.name }} -b ${{ secrets.BUCKET_NAME }}

--- a/.github/workflows/generate-module-metadata.yml
+++ b/.github/workflows/generate-module-metadata.yml
@@ -34,10 +34,10 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
-      - name: configure aws credentials
+      - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: arn:aws:iam::180024969694:role/githubActionsDeployRole
+          role-to-assume: ${{ secrets.ROLE_ARN }}
           role-session-name: GitHub_to_AWS_via_FederatedOIDC
           aws-region: us-west-2
       - name: Generate Metadata

--- a/.github/workflows/generate-module-metadata.yml
+++ b/.github/workflows/generate-module-metadata.yml
@@ -32,7 +32,7 @@ jobs:
       - name: configure aws credentials
         uses: aws-actions/configure-aws-credentials@v1.7.0
         with:
-          role-to-assume: ${{ secrets.ROLE_ARN }}
+          role-to-assume: arn:aws:iam::180024969694:role/githubActionsDeployRole
           role-session-name: GitHub_to_AWS_via_FederatedOIDC
           aws-region: us-west-2
       - name: Generate Metadata


### PR DESCRIPTION
### Feature: Add Github Action to collect module metadata and push data to S3

### When
- Triggered upon a release tag
- For now can be used with workflow dispatch as a test. It is available in my [fork](https://github.com/malachi-constant/idf-modules/actions/workflows/generate-module-metadata.yml)
<img width="1566" alt="Screenshot 2024-06-21 at 1 43 36 PM" src="https://github.com/awslabs/idf-modules/assets/6465221/51a2ba14-bbe9-48f7-b270-60570e5a1ed3">


### Example Output
<img width="1105" alt="Screenshot 2024-06-21 at 1 44 30 PM" src="https://github.com/awslabs/idf-modules/assets/6465221/87e82fd1-aed6-43ae-becd-0e7ba27ed8c6">



### What Else needs to get done
- Figure out what metadata needs to be present besides `name`, `readme`, `source_url`, `gitpath`, `version` - **This can be appended later on**
- [x] Publishing to S3 via the Action.
- Static Site setup using the published metadata as an index. **Outside of the scope of this PR and will be maintained internally not in Github.
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
