### PR TITLE
refactored emreks and emr-serverless modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### **Changed**
 
+- refactored the deployspec of `emr-on-eks` module and used seedfarmer to add/group metadata of 2 stacks
+- fixed the readme and app.py of `emr-serverless` module
+
 ### **Removed**
 
 =======

--- a/modules/compute/emr-on-eks/README.md
+++ b/modules/compute/emr-on-eks/README.md
@@ -87,10 +87,13 @@ parameters:
         key: ArtifactsBucketName
 ```
 
-### Module Metadata Outputs
+### Module Metadata RBAC Stack Outputs
 
 - `EmrJobExecutionRoleArn`: ARN for the EMR On EKS Execution Role
-- `VirtualClusterId`: Cluster ID for the EMR Virtual Cluster ID
+
+### Module Metadata EMR Stack Outputs
+
+- `VirtualClusterId`: Cluster ID for the EMR Virtual Cluster
 
 #### Output Example
 

--- a/modules/compute/emr-on-eks/deployspec.yaml
+++ b/modules/compute/emr-on-eks/deployspec.yaml
@@ -9,7 +9,8 @@ deploy:
       commands:
       - aws iam create-service-linked-role --aws-service-name emr-containers.amazonaws.com || true
       - cdk deploy --require-approval never --progress events --app "python app.py" --outputs-file ./cdk-exports-rbac.json ${SEEDFARMER_PROJECT_NAME}-${SEEDFARMER_DEPLOYMENT_NAME}-${SEEDFARMER_MODULE_NAME}-rbac
-      - python -c "import json; file=open('cdk-exports-rbac.json'); print(json.load(file)['${SEEDFARMER_PROJECT_NAME}-${SEEDFARMER_DEPLOYMENT_NAME}-${SEEDFARMER_MODULE_NAME}-rbac']['metadata'])" > rbac.json
+      # Export metadata of the rbac stack
+      - seedfarmer metadata convert -f cdk-exports-rbac.json || true
       - export EMR_SERVICE_ACCOUNT_ROLE=arn:${AWS_PARTITION}:iam::${AWS_ACCOUNT_ID}:role/AWSServiceRoleForAmazonEMRContainers
       # Assume the EKS_CLUSTER_ADMIN_ROLE and add our new service account role as a user in the aws_auth ConfigMap
       # Track https://github.com/aws/aws-cdk/issues/19753
@@ -21,9 +22,8 @@ deploy:
       # Un-Assume the EKS_CLUSTER_ADMIN_ROLE or the rest of the deploy will fail
       - unset AWS_ACCESS_KEY_ID && unset AWS_SECRET_ACCESS_KEY && unset AWS_SESSION_TOKEN
       - cdk deploy --require-approval never --progress events --app "python app.py" --outputs-file ./cdk-exports-emr.json ${SEEDFARMER_PROJECT_NAME}-${SEEDFARMER_DEPLOYMENT_NAME}-${SEEDFARMER_MODULE_NAME}
-      - python -c "import json; file=open('cdk-exports-emr.json'); print(json.load(file)['${SEEDFARMER_PROJECT_NAME}-${SEEDFARMER_DEPLOYMENT_NAME}-${SEEDFARMER_MODULE_NAME}']['metadata'])" > emr.json
-      # Merge 2 stacks outputs
-      - export SEEDFARMER_MODULE_METADATA=$(jq -sc '.[0] * .[1]' rbac.json emr.json)
+      # Export metadata
+      - seedfarmer metadata convert -f cdk-exports-emr.json || true
 destroy:
   phases:
     install:

--- a/modules/compute/emr-serverless/README.md
+++ b/modules/compute/emr-serverless/README.md
@@ -27,11 +27,14 @@ The parameters `(solution-*)` will resolve a custom text that is used as a descr
 
 - `EmrApplicationId`: name of the S3 Bucket configured to store MWAA Environment DAG artifacts
 - `EmrJobExecutionRoleArn`: name of the path in the S3 Bucket configured to store MWAA Environment DAG artifacts
+- `EmrSecurityGroupId`: Security group ID associated with EMR Serverless environment
 
 #### Output Example
 
 ```json
 {
-    "EmrApplicationId": "application id",
-    "EmrJobExecutionRoleArn": "arn:::::"
+    "EmrApplicationId": "00XXXXXXX",
+    "EmrJobExecutionRoleArn": "arn:::::",
+    "EmrSecurityGroupId": "sg-XXXX",
+
 }

--- a/modules/compute/emr-serverless/app.py
+++ b/modules/compute/emr-serverless/app.py
@@ -71,7 +71,7 @@ CfnOutput(
         {
             "EmrApplicationId": emr_serverless.emr_app.attr_application_id,
             "EmrJobExecutionRoleArn": emr_serverless.job_role.role_arn,
-            "EmrSecurityGroupId": emr_serverless.emr_security_group.security_group_id
+            "EmrSecurityGroupId": emr_serverless.emr_security_group.security_group_id,
         }
     ),
 )

--- a/modules/compute/emr-serverless/app.py
+++ b/modules/compute/emr-serverless/app.py
@@ -71,9 +71,7 @@ CfnOutput(
         {
             "EmrApplicationId": emr_serverless.emr_app.attr_application_id,
             "EmrJobExecutionRoleArn": emr_serverless.job_role.role_arn,
-            "EmrSecurityGroupId": emr_serverless.emr_security_group.security_group_id,
-            "EmrVpcId": vpc_id,
-            "EmrSubnets": private_subnet_ids,
+            "EmrSecurityGroupId": emr_serverless.emr_security_group.security_group_id
         }
     ),
 )


### PR DESCRIPTION
*Issue #, if available:*
Fixes #215 

*Description of changes:*
- refactored the deployspec of `emr-on-eks` module and used seedfarmer to add/group metadata of 2 stacks
- fixed the readme and app.py of `emr-serverless` module

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
