### PR TITLE
added a custom timeout for Self Managed Nodegroups 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - buckets
 - added support for `nvidia device plugin` for management of GPUs on EKS clusters
 - added support for adding taints and labels for self managed ngs
+- added a custom timeout for Self Managed Nodegroups for successful signalling
 
 ### **Changed**
 

--- a/data/eks_dockerimage-replication/versions/1.29.yaml
+++ b/data/eks_dockerimage-replication/versions/1.29.yaml
@@ -1,5 +1,5 @@
 ami:
-  version: 1.29.0-20240307
+  version: 1.29.3-20240703
 charts:
   nvidia_device_plugin:
     version: 0.14.5

--- a/modules/compute/eks/stack.py
+++ b/modules/compute/eks/stack.py
@@ -10,7 +10,7 @@ from typing import Any, Dict, List, Optional, cast
 
 import cdk_nag
 import yaml
-from aws_cdk import Aspects, CfnJson, RemovalPolicy, Stack, Tags
+from aws_cdk import Aspects, CfnJson, Duration, RemovalPolicy, Stack, Tags
 from aws_cdk import aws_aps as aps
 from aws_cdk import aws_autoscaling as asg
 from aws_cdk import aws_ec2 as ec2
@@ -368,7 +368,7 @@ class Eks(Stack):  # type: ignore
             auto_scaling_group_name=f"{dep_mod}-{ng_config.get('eks_ng_name')}",
             group_metrics=[asg.GroupMetrics.all()],
             instance_monitoring=asg.Monitoring.DETAILED,
-            signals=asg.Signals.wait_for_all(),
+            signals=asg.Signals.wait_for_all(timeout=Duration.minutes(10)),
         )
 
         self_managed_nodegroup.role.add_managed_policy(


### PR DESCRIPTION
*Issue #, if available:*
Fixes #245 

*Description of changes:*
added a custom timeout for Self Managed Nodegroups for successful signalling

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
