### PR TITLE
feat: added support for whitelisting custom CIDRs from SSM Parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### **Added**
 
+- added support for whitelisting custom CIDRs from SSM Parameters and AWS Codebuild IPs for being able to run seedfarmer commands
+
 ### **Changed**
 
 ### **Removed**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### **Added**
 
 - added support for whitelisting custom CIDRs from SSM Parameters and AWS Codebuild IPs for being able to run seedfarmer commands
+- added asg rolling update for self managed node groups
 
 ### **Changed**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### **Added**
 
-- added support for whitelisting custom CIDRs from SSM Parameters and AWS Codebuild IPs for being able to run seedfarmer commands
+- added support for whitelisting custom CIDRs from SSM Parameters, from a static entry list, and auto loads AWS Codebuild IPs for being able to run seedfarmer commands
 - added asg rolling update for self managed node groups
 
 ### **Changed**

--- a/manifests/local/compute-modules.yaml
+++ b/manifests/local/compute-modules.yaml
@@ -117,7 +117,8 @@ parameters:
         #   install_nvidia_device_plugin: True
       eks_node_spot: False
       eks_api_endpoint_private: False # This makes the EKS Endpoint PUBLIC and Private by default
-      #ips_to_whitelist: ${IPS_TO_WHITELIST} # It loads SSM Params from `.env` file
+      # ips_to_whitelist_from_ssm: ${IPS_TO_WHITELIST_FROM_SSM} # It loads SSM Params from `.env` file
+      # ips_to_whitelist_adhoc: ${IPS_TO_WHITELIST_ADHOC} # It loads list of CIDRs from `.env` file
       eks_secrets_envelope_encryption: True
   - name: eks-addons
     value:

--- a/manifests/local/compute-modules.yaml
+++ b/manifests/local/compute-modules.yaml
@@ -116,7 +116,8 @@ parameters:
         #       #operator: "Equal"
         #   install_nvidia_device_plugin: True
       eks_node_spot: False
-      eks_api_endpoint_private: False # This makes the EKS Endpoint PUBLIC by default
+      eks_api_endpoint_private: False # This makes the EKS Endpoint PUBLIC and Private by default
+      #ips_to_whitelist: ${IPS_TO_WHITELIST} # It loads SSM Params from `.env` file
       eks_secrets_envelope_encryption: True
   - name: eks-addons
     value:

--- a/modules/compute/eks/README.md
+++ b/modules/compute/eks/README.md
@@ -87,16 +87,27 @@ Security:
 - `eks_readonly_role_name`: The ReadOnly Role to be mapped to the `readonly-group` group of RBAC
 - `eks_node_spot`: If `eks_node_spot` is set to True, we deploy SPOT instances of the above `nodegroup_config` for you else we deploy `ON_DEMAND` instances.
 - `eks_secrets_envelope_encryption`: If set to True, we enable KMS secret for [envelope encryption](https://aws.amazon.com/about-aws/whats-new/2020/03/amazon-eks-adds-envelope-encryption-for-secrets-with-aws-kms/) for Kubernetes secrets.
-- `eks_api_endpoint_private`: If set to `True`, we deploy the EKS cluster with API endpoint set to [private mode](https://docs.aws.amazon.com/eks/latest/userguide/cluster-endpoint.html). By default, it is set to `PUBLIC AND PRIVATE` access mode (which by default whitelists `0.0.0.0/0` CIDR). If you want to whitelist specific CIDRs instead of the default whitelisted CIDR, you can set the below `ips_to_whitelist` attribute. You should not set the below attribute if eks_api_endpoint_private is set to `True`.
-- `ips_to_whitelist`: You can load a list of SSM Parameters in which your enterprise stores CIDRs to be whietlisted. The SSM Parameters should be declared in the `.env` file (feature supported by SeedFarmer). If you set this parameter, the EKS module automatically grabs the list of CODEBUILD public IPS from `ip-ranges.json` [file](https://ip-ranges.amazonaws.com/ip-ranges.json) based on the region it is operating, so your seedfarmer commands continue to work. Below is an example declaration:
+- `eks_api_endpoint_private`: If set to `True`, we deploy the EKS cluster with API endpoint set to [private mode](https://docs.aws.amazon.com/eks/latest/userguide/cluster-endpoint.html). By default, it is set to `PUBLIC AND PRIVATE` access mode (which whitelists `0.0.0.0/0` CIDR). If you want to whitelist custom CIDRs instead of the default whitelisted CIDR, you can either set `ips_to_whitelist_from_ssm` or `ips_to_whitelist_adhoc` attribute(s). You should not set either of them if `eks_api_endpoint_private` is set to `True`.
+- `ips_to_whitelist_from_ssm`: You can load a list of SSM Parameters in which your enterprise stores CIDRs to be whietlisted. The SSM Parameters should be declared in a `.env` file (feature supported by SeedFarmer). If you set this parameter, the EKS module also loads the list of CODEBUILD Public IPS from `ip-ranges.json` [file](https://ip-ranges.amazonaws.com/ip-ranges.json) based on the region of operation, so your seedfarmer commands continue to work. Below is an example declaration:
 
 ```yaml
 eks_api_endpoint_private: False
-ips_to_whitelist: ${IPS_TO_WHITELIST}
+ips_to_whitelist_from_ssm: ${IPS_TO_WHITELIST_FROM_SSM}
 ```
 
 ```.env
-IPS_TO_WHITELIST=["/company/org/ip-whitelists1", "/company/org/ip-whitelists2"]
+IPS_TO_WHITELIST_FROM_SSM=["/company/org/ip-whitelists1", "/company/org/ip-whitelists2"]
+```
+
+- `ips_to_whitelist_adhoc`: You can declare a list of Public CIDRs which needs to be whietlisted. The entities leveraging Public CIDRs can be declared in a `.env` file (feature supported by SeedFarmer). If you set this parameter, the EKS module also loads the list of CODEBUILD Public IPS from `ip-ranges.json` [file](https://ip-ranges.amazonaws.com/ip-ranges.json) based on the region of operation, so your seedfarmer commands continue to work. Below is an example declaration:
+
+```yaml
+eks_api_endpoint_private: False
+ips_to_whitelist_adhoc: ${IPS_TO_WHITELIST_ADHOC}
+```
+
+```.env
+IPS_TO_WHITELIST_ADHOC=["1.2.3.4/8", "11.2.33.44/8"]
 ```
 
 #### Optional Drivers/Addons/Plugins

--- a/modules/compute/eks/README.md
+++ b/modules/compute/eks/README.md
@@ -87,7 +87,20 @@ Security:
 - `eks_readonly_role_name`: The ReadOnly Role to be mapped to the `readonly-group` group of RBAC
 - `eks_node_spot`: If `eks_node_spot` is set to True, we deploy SPOT instances of the above `nodegroup_config` for you else we deploy `ON_DEMAND` instances.
 - `eks_secrets_envelope_encryption`: If set to True, we enable KMS secret for [envelope encryption](https://aws.amazon.com/about-aws/whats-new/2020/03/amazon-eks-adds-envelope-encryption-for-secrets-with-aws-kms/) for Kubernetes secrets.
-- `eks_api_endpoint_private`: If set to True, we deploy EKS cluster with API endpoint set to [private mode](https://docs.aws.amazon.com/eks/latest/userguide/cluster-endpoint.html).
+- `eks_api_endpoint_private`: If set to `True`, we deploy the EKS cluster with API endpoint set to [private mode](https://docs.aws.amazon.com/eks/latest/userguide/cluster-endpoint.html). By default, it is set to `PUBLIC AND PRIVATE` access mode (which by default whitelists `0.0.0.0/0` CIDR). If you want to whitelist specific CIDRs instead of the default whitelisted CIDR, you can set the below `ips_to_whitelist` attribute. You should not set the below attribute if eks_api_endpoint_private is set to `True`.
+- `ips_to_whitelist`: You can load a list of SSM Parameters in which your enterprise stores CIDRs to be whietlisted. The SSM Parameters should be declared in the `.env` file (feature supported by SeedFarmer). If you set this parameter, the EKS module automatically grabs the list of CODEBUILD public IPS from `ip-ranges.json` [file](https://ip-ranges.amazonaws.com/ip-ranges.json) based on the region it is operating, so your seedfarmer commands continue to work. Below is an example declaration:
+
+```yaml
+eks_api_endpoint_private: False
+ips_to_whitelist: ${IPS_TO_WHITELIST}
+```
+
+```.env
+IPS_TO_WHITELIST=["/company/org/ip-whitelists1", "/company/org/ip-whitelists2"]
+```
+
+#### Optional Drivers/Addons/Plugins
+
 - `deploy_aws_lb_controller`: Deploys the [ALB Ingress controller](https://docs.aws.amazon.com/eks/latest/userguide/alb-ingress.html). Default behavior is set to False
 - `deploy_external_dns`: Deploys the External DNS to interact with [AWS Route53](https://github.com/kubernetes-sigs/external-dns/blob/master/docs/tutorials/aws.md). Default behavior is set to False
 - `deploy_aws_ebs_csi`: Deploys the [AWS EBS](https://docs.aws.amazon.com/eks/latest/userguide/ebs-csi.html) Driver. Default behavior is set to False

--- a/modules/compute/eks/stack.py
+++ b/modules/compute/eks/stack.py
@@ -361,7 +361,10 @@ class Eks(Stack):  # type: ignore
             desired_capacity=ng_config.get("eks_node_quantity"),
             max_capacity=ng_config.get("eks_node_max_quantity"),
             min_capacity=ng_config.get("eks_node_min_quantity"),
-            update_policy=None,
+            update_policy=asg.UpdatePolicy.rolling_update(
+                max_batch_size=1,
+                min_instances_in_service=ng_config.get("eks_node_quantity"),
+            ),
             instance_type=ec2.InstanceType(str(ng_config.get("eks_node_instance_type"))),
             bootstrap_options=eks.BootstrapOptions(
                 kubelet_extra_args=KUBELET_EXTRA_ARGS if KUBELET_EXTRA_ARGS else None,

--- a/modules/compute/eks/tests/test_app.py
+++ b/modules/compute/eks/tests/test_app.py
@@ -21,6 +21,7 @@ def stack_defaults():
     os.environ["SEEDFARMER_PARAMETER_DATAPLANE_SUBNET_IDS"] = json.dumps(["subnet-12345", "subnet-54321"])
     os.environ["SEEDFARMER_PARAMETER_CONTROLPLANE_SUBNET_IDS"] = json.dumps(["subnet-12345", "subnet-54321"])
     os.environ["SEEDFARMER_PARAMETER_EKS_VERSION"] = "1.29"
+    os.environ["SEEDFARMER_PARAMETER_MOUNTPOINT_BUCKETS"] = json.dumps(["test-bucket1"])
     os.environ["SEEDFARMER_PARAMETER_EKS_COMPUTE"] = json.dumps(
         {
             "eks_nodegroup_config": [
@@ -44,6 +45,7 @@ def stack_defaults():
             "eks_node_spot": "False",
             "eks_api_endpoint_private": "False",
             "eks_secrets_envelope_encryption": "True",
+            "ips_to_whitelist": ["/test/sample1", "/test/sample2"],
         }
     )
     os.environ["SEEDFARMER_PARAMETER_EKS_ADDONS"] = json.dumps(
@@ -157,6 +159,15 @@ def test_controlplane_subnet_ids(stack_defaults):
         assert os.environ["SEEDFARMER_PARAMETER_CONTROLPLANE_SUBNET_IDS"] == ["subnet-12345", "subnet-54321"]
 
 
+def test_mp_s3_buckets(stack_defaults):
+    del os.environ["SEEDFARMER_PARAMETER_MOUNTPOINT_BUCKETS"]
+
+    with pytest.raises(Exception):
+        import app  # noqa: F401
+
+        assert os.environ["SEEDFARMER_PARAMETER_MOUNTPOINT_BUCKETS"] == ["test-bucket1"]
+
+
 def test_eks_compute(stack_defaults):
     del os.environ["SEEDFARMER_PARAMETER_EKS_COMPUTE"]
 
@@ -177,6 +188,7 @@ def test_eks_compute(stack_defaults):
             "eks_node_spot": "False",
             "eks_api_endpoint_private": "False",
             "eks_secrets_envelope_encryption": "True",
+            "ips_to_whitelist": ["/test/sample1", "/test/sample2"],
         }
 
 

--- a/modules/compute/eks/tests/test_stack.py
+++ b/modules/compute/eks/tests/test_stack.py
@@ -44,6 +44,7 @@ def test_synthesize_stack(stack_defaults):
         "eks_node_spot": "False",
         "eks_api_endpoint_private": "False",
         "eks_secrets_envelope_encryption": "True",
+        "ips_to_whitelist": ["/test/sample1", "/test/sample2"],
     }
 
     eks_addons_config = {
@@ -138,4 +139,32 @@ def test_synthesize_stack(stack_defaults):
         },
     )
 
-    # template.has_resource_properties("Custom::AWSCDK-EKS-Cluster")
+    # EKS Cluster Creator
+    template.resource_count_is("Custom::AWSCDK-EKS-Cluster", 1)
+
+    # Autoscaling group
+    # template.resource_count_is("AWS::AutoScaling::AutoScalingGroup", 1)
+
+    # Helm charts
+    template.resource_count_is("Custom::AWSCDK-EKS-HelmChart", 18)
+
+    # Security groups
+    template.resource_count_is("AWS::EC2::SecurityGroup", 1)
+
+    # Provider Lambda
+    template.resource_count_is("AWS::Lambda::Function", 2)
+
+    # Cluster Creator role
+    template.has_resource_properties(
+        "AWS::IAM::Role",
+        {
+            "AssumeRolePolicyDocument": {
+                "Statement": [
+                    {
+                        "Action": "sts:AssumeRoleWithWebIdentity",
+                        "Effect": "Allow",
+                    },
+                ],
+            },
+        },
+    )


### PR DESCRIPTION
<img width="465" alt="Screenshot 2024-07-10 at 10 49 39 PM" src="https://github.com/awslabs/idf-modules/assets/24925998/3a84adc2-db43-42c5-b7ab-fae2bea0cd75">


*Issue #, if available:*
Fixes #193 

*Description of changes:*
- added support for whitelisting custom CIDRs from SSM Parameters and auto load AWS Codebuild IPs for being able to run seedfarmer commands. Attached a screenshot for reference.
- This improves the security posture of EKS API endpoint such that, nodes communicate privately and any communication to the EKS APIs will be allowed from whitelisted customer CIDRs and AWS CODEBUILD IPs (for being able to run seedfarmer commands outside of VPC)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
