### PR TITLE
chore: exempt dummy module from integration check workflow

### DIFF
--- a/.github/workflows/check-integration-tests.yml
+++ b/.github/workflows/check-integration-tests.yml
@@ -24,6 +24,10 @@ jobs:
           for d in modules/*/* ; do
               MODULES+=("$d")
           done
+          exempt=(modules/dummy/blank)
+          for del in ${exempt[@]}; do
+              MODULES=("${MODULES[@]/$del}") 
+          done
           for m in "${MODULES[@]}" ; do
               if [ ! -d "${m}"/integ/ ]; then
                 echo "No Integration tests for ${m}"


### PR DESCRIPTION
*Issue #, if available:*
- Closes #230 


### Changes
- Exempts module `blank/dummy` from integration tests check workflow


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
