### PR TITLE
chore: update module checks workflow

### DIFF
--- a/.github/workflows/module-checks-dev-requirements-change.yml
+++ b/.github/workflows/module-checks-dev-requirements-change.yml
@@ -1,12 +1,11 @@
-name: Module Checks
+name: Module Checks Dev Requirements Change
 
 on:
   push:
     branches: 
       - "main"
     paths:
-      - "modules/**"
-      - ".github/workflows/module-checks.yml"
+      - "requirements-dev.txt"
 
   pull_request:
     branches:
@@ -14,8 +13,7 @@ on:
       - "release/*"
       - "stable"
     paths:
-      - "modules/**"
-      - ".github/workflows/module-checks.yml"
+      - "requirements-dev.txt"
 
 jobs:
   get-modules:
@@ -28,26 +26,12 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: Get changed files
-        id: changed-files
-        uses: tj-actions/changed-files@v44
-        with:
-          files: modules/**
-      - name: List all changed files
-        env:
-          ALL_CHANGED_FILES: ${{ steps.changed-files.outputs.all_changed_files }}
-        run: |
-          for file in ${ALL_CHANGED_FILES}; do
-            echo "$file was changed"
-          done
       - name: Get modules
         id: get-modules
-        env:
-          ALL_CHANGED_FILES: ${{ steps.changed-files.outputs.all_changed_files }}
         run: |
           set -x
           # Get all the modules that have the file "deployspec.yaml"
-          MODULES=$(echo $ALL_CHANGED_FILES | cut -d/ -f 2-3 | uniq)
+          MODULES=$(find modules -type f -name "deployspec.yaml" | cut -d/ -f 2-3 | uniq)
           # Create our json structure [{"module_name": "..."}]
           MODULES_JSON=$(echo "$MODULES" | jq -R -s 'split("\n")' | jq '[ .[] | select(length > 0) ]' | jq 'map({"module_name": .})')
           # Export the modules as json to the outputs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,12 +27,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - fsx-lustre
   - opensearch-serverless
   - opensearch
+- adds workflow specific to changes for `requirements-dev.txt` so all static checks are run
+
 
 ### **Changed**
 
 - fixed `storage/ecr` module integration test
 - update CDK in neptune module due to deprecated neptune version
 - update airflow version to 2.8.1
+- updated `get-modules` workflow to only run tests against changed files in `modules/**`
+
 
 ### **Removed**
 


### PR DESCRIPTION
## Describe your changes
- updated `get-modules` workflow to only run tests against changed files in `modules/**`
- adds workflow specific to changes for `requirements-dev.txt` so all static checks are run



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
