### PR TITLE
fixed unbound secrets key in eks module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### **Changed**
 
+- fixed unassigned secrets key in `eks` module
+
 ### **Removed**
 
 =======

--- a/modules/compute/eks/stack.py
+++ b/modules/compute/eks/stack.py
@@ -133,8 +133,7 @@ class Eks(Stack):  # type: ignore
         self.node_role = self._create_node_role(project_name, deployment_name, module_name, self.region)
 
         # KMS key for Kubernetes secrets envelope encryption
-        if eks_compute_config.get("eks_secrets_envelope_encryption"):
-            secrets_key = kms.Key(self, "SecretsKey")
+        secrets_key = kms.Key(self, "SecretsKey") if eks_compute_config.get("eks_secrets_envelope_encryption") else None
 
         # Creates an EKS Cluster
         eks_cluster, cm_patch, patches = self._create_eks_cluster(


### PR DESCRIPTION
*Issue #, if available:*

[L149](https://github.com/awslabs/idf-modules/blob/dca0f5c68b2bbe1bcb10727cb14b5c9271bf2cd8/modules/compute/eks/stack.py#L149) refers to unassigned local variable `secrets_key`.

```
File "/codebuild/output/src2320534162/src/bundle/module/app.py", line 57, in <module>
--
620 | stack = Eks(
621 | ^^^^
622 | File "/root/.venv/lib/python3.11/site-packages/jsii/_runtime.py", line 118, in __call__
623 | inst = super(JSIIMeta, cast(JSIIMeta, cls)).__call__(*args, **kwargs)
624 | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
625 | File "/codebuild/output/src2320534162/src/bundle/module/stack.py", line 149, in __init__
626 | secrets_key=secrets_key,
627 | ^^^^^^^^^^^
628 | UnboundLocalError: cannot access local variable 'secrets_key' where it is not associated with a value

```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
