### PR TITLE
fix: replace deprecated auto_delete_images with empty_on_delete in ecr module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### **Changed**
 
+- replace deprecated `auto_delete_images` with `empty_on_delete` &  bump CDK version in `ecr` module
+
 ### **Removed**
 
 =======

--- a/modules/storage/ecr/deployspec.yaml
+++ b/modules/storage/ecr/deployspec.yaml
@@ -3,7 +3,7 @@ deploy:
   phases:
     install:
       commands:
-      - npm install -g aws-cdk@2.114.1
+      - npm install -g aws-cdk@2.150.0
       - pip install -r requirements.txt
     build:
       commands:
@@ -14,7 +14,7 @@ destroy:
   phases:
     install:
       commands:
-      - npm install -g aws-cdk@2.114.1
+      - npm install -g aws-cdk@2.150.0
       - pip install -r requirements.txt
     build:
       commands:

--- a/modules/storage/ecr/requirements.txt
+++ b/modules/storage/ecr/requirements.txt
@@ -1,4 +1,4 @@
-aws-cdk-lib==2.114.1
+aws-cdk-lib==2.150.0
 aws_cdk.integ-tests-alpha==2.114.1a0
 constructs>=10.0.0,<11.0.0
 cdk-nag==2.12.29

--- a/modules/storage/ecr/stack.py
+++ b/modules/storage/ecr/stack.py
@@ -43,7 +43,7 @@ class EcrStack(Stack):
             repository_name=repository_name,
             image_tag_mutability=IMAGE_MUTABILITY[image_tag_mutability],
             removal_policy=RemovalPolicy.DESTROY if removal_policy in ["DESTROY"] else RemovalPolicy.RETAIN,
-            auto_delete_images=True if removal_policy in ["DESTROY"] else False,
+            empty_on_delete=True if removal_policy in ["DESTROY"] else False,
             image_scan_on_push=image_scan_on_push,
             encryption=ENCRYPTION[encryption],
             encryption_key=kms.Key.from_key_arn(self, "Key", key_arn=kms_key_arn)


### PR DESCRIPTION
*Description of changes:*
- replace [deprecated](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_ecr.Repository.html#autodeleteimagesspan-classapi-icon-api-icon-deprecated-titlethis-api-element-is-deprecated-its-use-is-not-recommended%EF%B8%8Fspan) `auto_delete_images` (based on custom resource) with `empty_on_delete` (natively supported by Cfn) in `ecr` module
- bump CDK to 2.150.0


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
