### PR TITLE
chore: pin external gh actions to hash

### DIFF
--- a/.github/workflows/check-integration-tests.yml
+++ b/.github/workflows/check-integration-tests.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Avoid Rate Limit With Wait
         run: sleep $((RANDOM % 15)) 
       - uses: actions/checkout@v4
-      - uses: JasonEtco/create-an-issue@v2
+      - uses: JasonEtco/create-an-issue@1b14a70e4d8dc185e5cc76d3bec9eab20257b2c5
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           MODULE_PATH: ${{ matrix.modules.module_path }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### **Changed**
 
+- pin external gh actions to hash
+
 ### **Removed**
 
 =======


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- pin external gh actions to hash

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
