### PR TITLE
chore: bump chart versions & fix s3 csi addon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### **Added**
 
 ### **Changed**
+- fix s3 csi driver addon in `eks` module
+- update charts versions in `1.29.yaml`
 
 =======
 

--- a/data/eks_dockerimage-replication/versions/1.29.yaml
+++ b/data/eks_dockerimage-replication/versions/1.29.yaml
@@ -10,7 +10,7 @@ charts:
   calico:
     version: 3.25.1
   cert_manager:
-    version: v1.15.3
+    version: v1.15.0
   cluster_autoscaler:
     version: 9.27.0
     replication:

--- a/data/eks_dockerimage-replication/versions/1.29.yaml
+++ b/data/eks_dockerimage-replication/versions/1.29.yaml
@@ -10,7 +10,7 @@ charts:
   calico:
     version: 3.25.1
   cert_manager:
-    version: v1.15.0
+    version: v1.16.2
   cluster_autoscaler:
     version: 9.27.0
     replication:

--- a/data/eks_dockerimage-replication/versions/1.29.yaml
+++ b/data/eks_dockerimage-replication/versions/1.29.yaml
@@ -10,7 +10,7 @@ charts:
   calico:
     version: 3.25.1
   cert_manager:
-    version: v1.15.0
+    version: v1.15.3
   cluster_autoscaler:
     version: 9.27.0
     replication:
@@ -32,18 +32,18 @@ charts:
     version: 1.9.0
   grafana:
     # skip: true
-    version: 6.52.4
+    version: 8.6.1
   kured:
     version: 4.4.2
   kyverno:
     version: 2.7.2
   kyverno_policy_reporter:
-    version: v2.18.0
+    version: v2.24.2
   metrics_server:
     version: 3.9.0
   prometheus_stack:
     # skip: true
-    version: 45.8.1
+    version: 66.2.2
   secrets_manager_csi_driver:
     version: 1.3.2
 additional_images:

--- a/modules/compute/eks/stack.py
+++ b/modules/compute/eks/stack.py
@@ -919,7 +919,6 @@ class Eks(Stack):  # type: ignore
             name="s3-csi-driver-sa",
             namespace="kube-system",
             labels={"app.kubernetes.io/name": "aws-mountpoint-s3-csi-driver"},
-            # annotations={"eks.amazonaws.com/role-arn": s3_addon_role.role_arn},
         )
 
         s3_csi_service_account.role.attach_inline_policy(
@@ -1683,7 +1682,6 @@ class Eks(Stack):  # type: ignore
                 {
                     "installCRDs": True,
                     "extraArgs": ["--dns01-recursive-nameservers-only=false"],
-                    # "podSecurityPolicy": {"enabled": False},
                     "serviceAccount": {
                         "create": False,
                         "name": cert_manager_service_account.service_account_name,


### PR DESCRIPTION
*Description of changes:*
- bump grafana, kyverno, prometheus, and cert manager chart versions
- fix s3 csi addon

avoids below issues with outdated charts
```
<REDACTED> | 3:59:36 PM | CREATE_FAILED        | Custom::AWSCDK-EKS-HelmChart          | cluster/chart-prometheus-chart/Resource/Default (clusterchartprometheuschartF4492F33) Received response status [FAILED] from custom resource. Message returned: Error: b'Release "prometheus-for-amp" does not exist. Installing it now.\nError: 5 errors occurred:\n\t* Internal error occurred: failed calling webhook "mservice.elbv2.k8s.aws": failed to call webhook: Post "https://aws-load-balancer-webhook-service.kube-system.svc:443/mutate-v1-service?timeout=10s": no endpoints available for service "aws-load-balancer-webhook-service"\n\t* Internal error occurred: failed calling webhook "mservice.elbv2.k8s.aws": failed to call webhook: Post "https://aws-load-balancer-webhook-service.kube-system.svc:443/mutate-v1-service?timeout=10s": no endpoints available for service "aws-load-balancer-webhook-service"\n\t* Internal error occurred: failed calling webhook "mservice.elbv2.k8s.aws": failed to call webhook: Post "https://aws-load-balancer-webhook-service.kube-system.svc:443/mutate-v1-service?timeout=10s": no endpoints available for service "aws-load-balancer-webhook-service"\n\t* Internal error occurred: failed calling webhook "mservice.elbv2.k8s.aws": failed to call webhook: Post "https://aws-load-balancer-webhook-service.kube-system.svc:443/mutate-v1-service?timeout=10s": no endpoints available for service "aws-load-balancer-webhook-service"\n\t* Internal error occurred: failed calling webhook "mservice.elbv2.k8s.aws": failed to call webhook: Post "https://aws-load-balancer-webhook-service.kube-system.svc:443/mutate-v1-service?timeout=10s": no endpoints available for service "aws-load-balancer-webhook-service"\n\n\n'

Received response status [FAILED] from custom resource. Message returned: Error: b'Release "policy-reporter" does not exist. Installing it now.\nError: 3 errors occurred:\n\t* Internal error occurred: failed calling webhook "mservice.elbv2.k8s.aws": failed to call webhook: Post "https://aws-load-balancer-webhook-service.kube-system.svc:443/mutate-v1-service?timeout=10s": no endpoints available for service "aws-load-balancer-webhook-service"\n\t* Internal error occurred: failed calling webhook "mservice.elbv2.k8s.aws": failed to call webhook: Post "https://aws-load-balancer-webhook-service.kube-system.svc:443/mutate-v1-service?timeout=10s": no endpoints available for service "aws-load-balancer-webhook-service"\n\t* Internal error occurred: failed calling webhook "mservice.elbv2.k8s.aws": failed to call webhook: Post "https://aws-load-balancer-webhook-service.kube-system.svc:443/mutate-v1-service?timeout=10s": no endpoints available for service "aws-load-balancer-webhook-service"\n\n\n' Logs: /aws/lambda/idf-hello-compute-eks12-awscdkawse-Handler886CB40B-e4FVb9xFp1Ot at invokeUserFunction (/var/task/framework.js:2:6) at process.processTicksAndRejections (node:internal/process/task_queues:95:5) at async onEvent (/var/task/framework.js:1:369) at async Runtime.handler (/var/task/cfn-response.js:1:1573) (RequestId: 948303b0-d0a8-4cd9-94cd-726bca7d040d)
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
