### PR TITLE
fix: add eks:DescribeClusterVersions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## UNRELEASED
 
 ### **Added**
+
+### **Changed**
+- add eks:DescribeClusterVersions to eks admin role
+
+### **Removed**
+
+=======
+
+## v1.14.0 (2025-01-23)
+
+### **Added**
 - add prometheus and prometheus-workspaces endpoints
 - adding eks support v1.30 in datafiles `1.30.yaml`
 

--- a/modules/compute/eks/stack.py
+++ b/modules/compute/eks/stack.py
@@ -670,6 +670,7 @@ class Eks(Stack):  # type: ignore
             "Effect": "Allow",
             "Action": [
                 "eks:DescribeCluster",
+                "eks:DescribeClusterVersions",
                 "iam:Get*",
                 "cloudformation:List*",
                 "cloudformation:Describe*",


### PR DESCRIPTION
*Issue, if available:*
```
[Container] 2025/03/07 22:50:50.210655 Running command if [ -n "$SEEDFARMER_PARAMETER_EKS_ADMIN_ROLE_NAME" ] ; then
...

Error: describing cluster versions: operation error EKS: DescribeClusterVersions, https response 
error StatusCode: 403, RequestID: 7e7cf37e-3a92-409e-92b1-58fd38fe5499, api error 
AccessDeniedException: User: arn:aws:sts::<REDACTED>:assumed-role/addf-eks-viz-core-
eks-us-west-2-masterrole/aws-auth-ops is not authorized to perform: eks:DescribeClusterVersions
 on resource: arn:aws:eks:us-west-2:<REDACTED:*
```

*Description of changes:*
Adding missing eks:DescribeClusterVersions permission to eks cluster admin role

*Testing:*

![image](https://github.com/user-attachments/assets/dd2010d0-c084-48a0-b5b8-ddc2bc167514)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
